### PR TITLE
beautify array key with assigning to temp var

### DIFF
--- a/SettingsFactory.module
+++ b/SettingsFactory.module
@@ -137,8 +137,9 @@ class SettingsFactory extends WireData implements Module, ConfigurableModule  {
 
 		foreach ($settingsFields as $key => $value) {
 			if ($nonDefaultLanguages && $user->language !== $languages->getDefault()) {
-				if (array_key_exists($key . "__" . $user->language->id, $dataArray)) {
-					$newDataArray[$key] = ($dataArray[$key . "__" . $user->language->id]) ? $dataArray[$key . "__" . $user->language->id] : $dataArray[$key];
+				$key_lang = $key . "__" . $user->language->id;
+				if (array_key_exists($key_lang, $dataArray)) {
+					$newDataArray[$key] = $dataArray[$key_lang] ? $dataArray[$key_lang] : $dataArray[$key];
 				} else {
 					$newDataArray[$key] = $dataArray[$key];
 				}


### PR DESCRIPTION
Hello, 

I think I've also found a potential bug.
for instance in line 141~142 a localized valid value == 0 will not pass the conditional test, thus it will not be set.

We have two options:
1. Set a localized value when a localized key exists (thus assigning zeros and empty strings)
2. Set a localized value only when the string value is not the empty string (zeros will still be set) `((string)$dataArray[$key_lang] !== '') ? ...`